### PR TITLE
[feat] fastDiary에서 keyword가 null값인지 체크하여 모달창을 띄우기

### DIFF
--- a/src/components/FastDiarySteps/FastDiaryStep6/FastDiaryStep6.jsx
+++ b/src/components/FastDiarySteps/FastDiaryStep6/FastDiaryStep6.jsx
@@ -1,4 +1,5 @@
 import * as S from '../FastDiaryStep.style'
+import { useState } from 'react'
 import { useRecoilState } from 'recoil'
 import { realizedKeyword } from '../../../recoil/atoms'
 import { useKeywordNullCheck } from '../../../hooks/useKeywordNullCheck'
@@ -18,9 +19,6 @@ export default function FastDiaryStep6({onNext, onPrev}){
     }
 
     const onClickSubmit = ()=>{
-        if(checkNull === true){
-            openModal()
-        }
         {checkNull === true ? openModal() :
             //api 연결 코드 들어갈 부분 
             onNext()

--- a/src/components/FastDiarySteps/FastDiaryStep6/FastDiaryStep6.jsx
+++ b/src/components/FastDiarySteps/FastDiaryStep6/FastDiaryStep6.jsx
@@ -1,6 +1,7 @@
 import * as S from '../FastDiaryStep.style'
 import { useRecoilState } from 'recoil'
-import { feelingKeyword, whenKeyword, whereKeyword, whoKeyword, whatKeyword, realizedKeyword } from '../../../recoil/atoms'
+import { realizedKeyword } from '../../../recoil/atoms'
+import { useKeywordNullCheck } from '../../../hooks/useKeywordNullCheck'
 import { useModal } from '../../../hooks/common/useModal'
 import LargeQuestion from '../Questions/LargeQustion'
 import BtnNext from '../../common/buttons/Next/BtnNext'
@@ -10,27 +11,21 @@ import DiaryErrorModal from '../../Modal/DiaryErrorModal'
 export default function FastDiaryStep6({onNext, onPrev}){
     const [realized, setRealized] = useRecoilState(realizedKeyword);
     const [isOpen, openModal, closeModal] = useModal();
+    const checkNull = useKeywordNullCheck();
 
     const handleChange = (event)=>{
         setRealized(event.target.value)
-        console.log(keywords)
     }
-/*
-    const checkNull = ()=>{
-     //   const values = Object.values(keywords);
-        values.forEach(value =>{
-            if(value === ''){
-                console.log('no!')
-                
-            }
-        })
-    }*/
 
     const onClickSubmit = ()=>{
-        openModal()
-     /*   checkNull()
-        setKeywords({...keywords, realized: realized})
-        onNext()*/
+        if(checkNull === true){
+            openModal()
+        }
+        {checkNull === true ? openModal() :
+            //api 연결 코드 들어갈 부분 
+            onNext()
+        }
+
     }
 
     return(

--- a/src/components/FastDiarySteps/FastDiaryStep6/FastDiaryStep6.jsx
+++ b/src/components/FastDiarySteps/FastDiaryStep6/FastDiaryStep6.jsx
@@ -1,5 +1,4 @@
 import * as S from '../FastDiaryStep.style'
-import { useState } from 'react'
 import { useRecoilState } from 'recoil'
 import { realizedKeyword } from '../../../recoil/atoms'
 import { useKeywordNullCheck } from '../../../hooks/useKeywordNullCheck'
@@ -20,7 +19,7 @@ export default function FastDiaryStep6({onNext, onPrev}){
 
     const onClickSubmit = ()=>{
         {checkNull === true ? openModal() :
-            //api 연결 코드 들어갈 부분 
+            //api 연결 이벤트
             onNext()
         }
 

--- a/src/hooks/useKeywordNullCheck.jsx
+++ b/src/hooks/useKeywordNullCheck.jsx
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react'
+import { useRecoilValue } from 'recoil'
+import { feelingKeyword, whenKeyword, whereKeyword, whoKeyword, whatKeyword, realizedKeyword } from '../recoil/atoms'
+
+export function useKeywordNullCheck(){
+    const [isNull, setIsNull] = useState(false);
+    const keywords = [
+        useRecoilValue(feelingKeyword),
+        useRecoilValue(whenKeyword),
+        useRecoilValue(whereKeyword),
+        useRecoilValue(whoKeyword),
+        useRecoilValue(whatKeyword),
+        useRecoilValue(realizedKeyword),
+    ];
+
+    useEffect(()=>{
+        keywords.map((keyword, idx)=>{
+            console.log(keyword, idx)
+            if(keyword === ''){
+                setIsNull(true);
+            }
+        })
+    },[])
+
+    return isNull
+}

--- a/src/hooks/useKeywordNullCheck.jsx
+++ b/src/hooks/useKeywordNullCheck.jsx
@@ -23,6 +23,6 @@ export function useKeywordNullCheck(){
             }
         })
     },[keywords])
-    return isNull
 
+    return isNull
 }

--- a/src/hooks/useKeywordNullCheck.jsx
+++ b/src/hooks/useKeywordNullCheck.jsx
@@ -3,7 +3,7 @@ import { useRecoilValue } from 'recoil'
 import { feelingKeyword, whenKeyword, whereKeyword, whoKeyword, whatKeyword, realizedKeyword } from '../recoil/atoms'
 
 export function useKeywordNullCheck(){
-    const [isNull, setIsNull] = useState(false);
+    const [isNull, setIsNull] = useState();
     const keywords = [
         useRecoilValue(feelingKeyword),
         useRecoilValue(whenKeyword),
@@ -14,13 +14,15 @@ export function useKeywordNullCheck(){
     ];
 
     useEffect(()=>{
+        setIsNull(false);
         keywords.map((keyword, idx)=>{
             console.log(keyword, idx)
             if(keyword === ''){
                 setIsNull(true);
+                
             }
         })
-    },[])
-
+    },[keywords])
     return isNull
+
 }

--- a/src/recoil/atoms.js
+++ b/src/recoil/atoms.js
@@ -11,19 +11,6 @@ export const UserDiaryType = atom({
    default: '',
    effects_UNSTABLE: [persistAtom]
 });
-/*
-export const fastDiaryKeywords = atom({
-    key: "fastDiaryKeywords",
-    default:{
-        feeling: '',
-        what: '',
-        who: '',
-        when: '',
-        where: '',
-        realized: ''
-    },
-    effects_UNSTABLE: [persistAtom]
-});*/
 
 export const feelingKeyword = atom({
     key: "feeling",
@@ -58,5 +45,38 @@ export const whatKeyword = atom({
 export const realizedKeyword = atom({
     key: "realized",
     default:'',
+    effects_UNSTABLE: [persistAtom]
+});
+
+export const diaryTitle = atom({
+    key: "diaryTitle",
+    default: '',
+    effects_UNSTABLE: [persistAtom]
+});
+
+export const diaryContent = atom({
+    key: "diaryContent",
+    default: '',
+    effects_UNSTABLE: [persistAtom]
+});
+
+export const diaryFeeling = atom({
+    key: "diaryFeeling",
+    default: '',
+    effects_UNSTABLE: [persistAtom]
+});
+
+export const diaryImage = atom({
+    key: "diaryImage",
+    default: '',
+    effects_UNSTABLE: [persistAtom]
+});
+
+export const diaryAdvice = atom({
+    key: "diaryAdvice",
+    default: {
+        spicy: '',
+        kind: '',
+    },
     effects_UNSTABLE: [persistAtom]
 });


### PR DESCRIPTION
## Related Issue 🍫

- close : #58 

## Summary 🍪

- useKeywordNullCheck 커스텀 훅을 작성하였습니다. 내부에서 null인지 판단하는 isNull(bool type) state를 반환하여 줍니다.
Step6 에서는 이 값이 true면 모달창을 띄우고, false면 api연결을 진행하고 뷰 페이지로 이동합니다. 
- 훅 내부에서는 useRecoilValue로 atom값들을 받아와 배열에 저장하고, map을 통하여 값이 비었으면 state를 true로 변경합니다.
- 무한 렌더링 방지를 위하여 useEffect 도 사용하였습니다. 

## Before i request PR review 🍰

- 훨씬 깔끔해진 것 같습니다!!!!
- 이건 다른 얘기인데, 이왕 같은 컴포넌트를 수정하는 김에 같이 고쳐보는 것이 나을 것 같아 질문드립니다. 지금 onNext 값으로 받아오는 함수가, 페이지에서 '다음 페이지 값'을 설정해두고 그 함수를 퍼널의 각 Step으로 보내는 형식입니다. 그런데 api 연결이 Step6 컴포넌트에서 일어나서, api 실행 후 data 값을 넘겨주는 부분에서 로직의 오류가 발생합니다. 
그래서 제 생각에는... Step6 에서만 컴포넌트 내부에서 onNext로 넘겨줄 navigate 함수를 따로 구현해주는 것이 어떨까 싶습니다.
- 감사합니다 👍 👍 👍  
