### PR TITLE
[feat] 감정별 일기 조회 api 연결

### DIFF
--- a/src/components/FastDiarySteps/FastDiaryStep6/FastDiaryStep6.jsx
+++ b/src/components/FastDiarySteps/FastDiaryStep6/FastDiaryStep6.jsx
@@ -27,7 +27,16 @@ export default function FastDiaryStep6({onNext, onPrev}){
 
     return(
         <S.FastDiaryStepWrapper>
-            {isOpen && <DiaryErrorModal closeModal={closeModal}/>}
+            {isOpen && 
+                <DiaryErrorModal 
+                    closeModal = {closeModal} 
+                    top = 'none'
+                >
+                    모든 질문에 답변해주세요.<br/>
+                    답변을 토대로 AI일기가 생성됩니다.
+                </DiaryErrorModal>
+            }
+            
             <LargeQuestion>
                 하루를 돌아보면서<br/>
                 느꼈던 것들이 있다면 말해줄래?

--- a/src/components/Modal/DiaryErrorModal.jsx
+++ b/src/components/Modal/DiaryErrorModal.jsx
@@ -2,18 +2,23 @@ import * as S from './Modal.style'
 import Modal from './Modal'
 import BtnSubmit from '../common/buttons/Submit/BtnSubmit'
 
-export default function DiaryErrorModal({closeModal}){
-    return(
-        <Modal top = 'none'>
-            <S.Content>
-                모든 질문에 답변해주세요.<br/>
-                답변을 토대로 AI일기가 생성됩니다.
-            </S.Content>
-            <S.ButtonField>
-                <BtnSubmit onClick={()=>{closeModal()}}width='27.2rem' $color={({ theme }) => theme.colors.pink.red_pink}>
-                    돌아가기
-                </BtnSubmit>
-            </S.ButtonField>
-        </Modal>
-    )
+export default function DiaryErrorModal({closeModal, top, children}){
+  return(
+    <Modal top = {top}>
+      <S.Content>
+        {children}
+      </S.Content>
+      <S.ButtonField>
+        <BtnSubmit 
+          onClick = {() => { 
+            closeModal();
+          }}
+          width = '27.2rem' 
+          $color = {({ theme }) => theme.colors.pink.red_pink}
+        >
+          돌아가기
+        </BtnSubmit>
+      </S.ButtonField>
+    </Modal>
+  )
 }

--- a/src/components/common/buttons/EmotionType/EmotionType.jsx
+++ b/src/components/common/buttons/EmotionType/EmotionType.jsx
@@ -1,16 +1,21 @@
 import * as S from "./EmotionType.style";
 import { useNavigate } from "react-router-dom";
-// API 통신을 위한 import
-// import { usePostFeelingList } from "../../../../hooks/queries/mypage/usePostFeelingList";
+import { usePostFeelingList } from "../../../../hooks/queries/mypage/usePostFeelingList";
 
 export default function BtnEmotionType({name, btnEnum}) {
-    const navigate=useNavigate();
+    const { mutation } = usePostFeelingList();
+    const navigate = useNavigate();
+    
     const handleClick = () => {
-        // 백에서 API 가져와서 Feeling btnEnum 넘기고 해당 Feeling에 해당하는 일기를 불러오는 페이지로 들어가기
-        // const response = usePostFeelingList(btnEnum)
-        // navigate(`/searchbyemotion/diarylist/response?=${response}`);
-
-        navigate('/searchbyemotion/diarylist')
+        const body = {
+            feeling : btnEnum,
+        }
+        mutation.mutate(body, {
+            onSuccess: (response) => {
+                console.log(response)
+                navigate('/searchbyemotion/diarylist')
+            }
+        })
     }
     
     return (

--- a/src/components/common/buttons/EmotionType/EmotionType.jsx
+++ b/src/components/common/buttons/EmotionType/EmotionType.jsx
@@ -1,32 +1,11 @@
 import * as S from "./EmotionType.style";
-import { useRecoilState } from "recoil";
-import { diaryList } from "../../../../recoil/atoms";
-import { useNavigate } from "react-router-dom";
-import { usePostFeelingList } from "../../../../hooks/queries/mypage/usePostFeelingList";
 
-export default function BtnEmotionType({name, btnEnum}) {
-    const [diaryListAtom, setDiaryListAtom] = useRecoilState(diaryList);
-    const { mutation } = usePostFeelingList();
-    const navigate = useNavigate();
-    
-    const handleClick = () => {
-        const body = {
-            feeling : btnEnum,
-        }
-        mutation.mutate(body, {
-            onSuccess: (response) => {
-                console.log(response);
-                setDiaryListAtom(response.data.feelingList);    
-                navigate('/searchbyemotion/diarylist');
-            }
-        })
-    }
-    
-    return (
-        <S.EmotionTypeBtnWrapper onClick={handleClick}>
-            <S.EmotionTypeBtnText>
-                {name}
-            </S.EmotionTypeBtnText>
-        </S.EmotionTypeBtnWrapper>
-    )
+export default function BtnEmotionType({name,  onClick}) {
+  return (
+    <S.EmotionTypeBtnWrapper onClick = {() => {onClick()}}>
+      <S.EmotionTypeBtnText>
+          {name}
+      </S.EmotionTypeBtnText>
+    </S.EmotionTypeBtnWrapper>
+  )
 }

--- a/src/components/common/buttons/EmotionType/EmotionType.jsx
+++ b/src/components/common/buttons/EmotionType/EmotionType.jsx
@@ -1,8 +1,11 @@
 import * as S from "./EmotionType.style";
+import { useRecoilState } from "recoil";
+import { diaryList } from "../../../../recoil/atoms";
 import { useNavigate } from "react-router-dom";
 import { usePostFeelingList } from "../../../../hooks/queries/mypage/usePostFeelingList";
 
 export default function BtnEmotionType({name, btnEnum}) {
+    const [diaryListAtom, setDiaryListAtom] = useRecoilState(diaryList);
     const { mutation } = usePostFeelingList();
     const navigate = useNavigate();
     
@@ -12,8 +15,9 @@ export default function BtnEmotionType({name, btnEnum}) {
         }
         mutation.mutate(body, {
             onSuccess: (response) => {
-                console.log(response)
-                navigate('/searchbyemotion/diarylist')
+                console.log(response);
+                setDiaryListAtom(response.data.feelingList);    
+                navigate('/searchbyemotion/diarylist');
             }
         })
     }

--- a/src/hooks/queries/mypage/usePostFeelingList.jsx
+++ b/src/hooks/queries/mypage/usePostFeelingList.jsx
@@ -4,14 +4,15 @@ import { useMutation } from "react-query";
 export const postFeelingList = async (body) => {
     const response =  await serverInstance.post('/api/diary/list/feeling', body);
     return response.data;
-}
+};
 
-export const usePostFeelingList = () => { 
+const usePostFeelingList = () => { 
     const mutation = useMutation({
         mutationFn: postFeelingList,
         onSuccess: (data) => {
             console.log('요청에 성공했습니다.', data)
         }
     })
-    return { mutation };
-}
+    return mutation;
+};
+export default usePostFeelingList;

--- a/src/pages/DiaryList/DiaryList.jsx
+++ b/src/pages/DiaryList/DiaryList.jsx
@@ -1,4 +1,6 @@
 import * as S from './DiaryList.sytle';
+import { useRecoilValue } from 'recoil';
+import { diaryList } from '../../recoil/atoms';
 import { useNavigate, useParams } from 'react-router-dom';
 import BtnBack from '../../components/common/buttons/Back/BtnBack';
 import DiaryListComponent from '../../components/common/DiaryListComponent/DiaryListComponent';
@@ -13,12 +15,9 @@ import DiaryListComponent from '../../components/common/DiaryListComponent/Diary
 ))}*/
 
 export default function DiaryList(){
-    
-    const params = useParams();
-    const responseObject = params.response;
-
-    const navigate=useNavigate();
-    const handleBackButton=()=>{
+    const diaryListAtom = useRecoilValue(diaryList)
+    const navigate = useNavigate();
+    const handleBackButton = () => {
         navigate('/searchbyemotion');
     };
     
@@ -30,7 +29,14 @@ export default function DiaryList(){
             </S.BackButtonWrapper>
 
             <S.DiaryListComponentWrapper>
-
+                {diaryListAtom.map((item) => (
+                    <DiaryListComponent
+                        key={item.diaryId}
+                        feelingListId={item.diaryId}
+                        feelingListTitle={item.diaryTitle}
+                        feelingListDate={item.createdDate}
+                    />
+                ))}
             </S.DiaryListComponentWrapper>
         </S.DiaryListWrapper>
     );

--- a/src/pages/DiaryList/DiaryList.jsx
+++ b/src/pages/DiaryList/DiaryList.jsx
@@ -1,12 +1,12 @@
 import * as S from './DiaryList.sytle';
 import { useRecoilValue } from 'recoil';
-import { diaryList } from '../../recoil/atoms';
-import { useNavigate, useParams } from 'react-router-dom';
+import { diaryListAtom } from '../../recoil/atoms';
+import { useNavigate } from 'react-router-dom';
 import BtnBack from '../../components/common/buttons/Back/BtnBack';
 import DiaryListComponent from '../../components/common/DiaryListComponent/DiaryListComponent';
 
 export default function DiaryList(){
-    const diaryListAtom = useRecoilValue(diaryList);
+    const diaryList = useRecoilValue(diaryListAtom);
     const navigate = useNavigate();
 
     const handleBackButton = () => {
@@ -21,7 +21,7 @@ export default function DiaryList(){
             </S.BackButtonWrapper>
 
             <S.DiaryListComponentWrapper>
-                {diaryListAtom.map((item) => (
+                {diaryList.map((item) => (
                     <DiaryListComponent
                         key={item.diaryId}
                         feelingListId={item.diaryId}

--- a/src/pages/DiaryList/DiaryList.jsx
+++ b/src/pages/DiaryList/DiaryList.jsx
@@ -1,35 +1,36 @@
 import * as S from './DiaryList.sytle';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { diaryListAtom } from '../../recoil/atoms';
 import { useNavigate } from 'react-router-dom';
 import BtnBack from '../../components/common/buttons/Back/BtnBack';
 import DiaryListComponent from '../../components/common/DiaryListComponent/DiaryListComponent';
 
 export default function DiaryList(){
-    const diaryList = useRecoilValue(diaryListAtom);
-    const navigate = useNavigate();
+  const [diaryList, setDiaryList] = useRecoilState(diaryListAtom);
+  const navigate = useNavigate();
 
-    const handleBackButton = () => {
-        navigate('/searchbyemotion');
-    };
-    
-    return(       
-        <S.DiaryListWrapper>
+  const handleBackButton = () => {
+    setDiaryList({});
+    navigate('/searchbyemotion');
+  };
+  
+  return(       
+    <S.DiaryListWrapper>
 
-            <S.BackButtonWrapper>
-                <BtnBack onClick={() => {handleBackButton()}}/>
-            </S.BackButtonWrapper>
+      <S.BackButtonWrapper>
+        <BtnBack onClick={() => {handleBackButton()}}/>
+      </S.BackButtonWrapper>
 
-            <S.DiaryListComponentWrapper>
-                {diaryList.map((item) => (
-                    <DiaryListComponent
-                        key={item.diaryId}
-                        feelingListId={item.diaryId}
-                        feelingListTitle={item.diaryTitle}
-                        feelingListDate={item.createdDate}
-                    />
-                ))}
-            </S.DiaryListComponentWrapper>
-        </S.DiaryListWrapper>
-    );
+      <S.DiaryListComponentWrapper>
+          {diaryList.map((item) => (
+            <DiaryListComponent
+              key = {item.diaryId}
+              feelingListId = {item.diaryId}
+              feelingListTitle = {item.diaryTitle}
+              feelingListDate = {item.createdDate}
+            />
+          ))}
+      </S.DiaryListComponentWrapper>
+    </S.DiaryListWrapper>
+  );
 }

--- a/src/pages/DiaryList/DiaryList.jsx
+++ b/src/pages/DiaryList/DiaryList.jsx
@@ -4,19 +4,11 @@ import { diaryList } from '../../recoil/atoms';
 import { useNavigate, useParams } from 'react-router-dom';
 import BtnBack from '../../components/common/buttons/Back/BtnBack';
 import DiaryListComponent from '../../components/common/DiaryListComponent/DiaryListComponent';
-/*
-{responseObject.map((item) => (
-    <DiaryListComponent
-        key={item.diaryId}
-        feelingListId={item.diaryId}
-        feelingListTitle={item.diaryTitle}
-        feelingListDate={item.createdDate}
-    />
-))}*/
 
 export default function DiaryList(){
-    const diaryListAtom = useRecoilValue(diaryList)
+    const diaryListAtom = useRecoilValue(diaryList);
     const navigate = useNavigate();
+
     const handleBackButton = () => {
         navigate('/searchbyemotion');
     };

--- a/src/pages/DiaryList/DiaryList.jsx
+++ b/src/pages/DiaryList/DiaryList.jsx
@@ -1,7 +1,16 @@
-import * as S from './DiaryList.sytle'
+import * as S from './DiaryList.sytle';
 import { useNavigate, useParams } from 'react-router-dom';
 import BtnBack from '../../components/common/buttons/Back/BtnBack';
 import DiaryListComponent from '../../components/common/DiaryListComponent/DiaryListComponent';
+/*
+{responseObject.map((item) => (
+    <DiaryListComponent
+        key={item.diaryId}
+        feelingListId={item.diaryId}
+        feelingListTitle={item.diaryTitle}
+        feelingListDate={item.createdDate}
+    />
+))}*/
 
 export default function DiaryList(){
     
@@ -21,14 +30,7 @@ export default function DiaryList(){
             </S.BackButtonWrapper>
 
             <S.DiaryListComponentWrapper>
-                {responseObject.map((item) => (
-                    <DiaryListComponent
-                        key={item.diaryId}
-                        feelingListId={item.diaryId}
-                        feelingListTitle={item.diaryTitle}
-                        feelingListDate={item.createdDate}
-                    />
-                ))}
+
             </S.DiaryListComponentWrapper>
         </S.DiaryListWrapper>
     );

--- a/src/pages/SearchByEmotion/SearchByEmotion.jsx
+++ b/src/pages/SearchByEmotion/SearchByEmotion.jsx
@@ -1,12 +1,13 @@
-import * as S from './SearchByEmotion.style'
-import { useNavigate } from 'react-router-dom'
-import PopUp from '../../components/PopUp/PopUp'
-import BtnBack from '../../components/common/buttons/Back/BtnBack'
-import SearchByEmotionPopUp from './SearchByEmotionPopUp/SearchByEmotionPopUp'
+import * as S from './SearchByEmotion.style';
+import { useNavigate } from 'react-router-dom';
+import PopUp from '../../components/PopUp/PopUp';
+import BtnBack from '../../components/common/buttons/Back/BtnBack';
+import SearchByEmotionPopUp from './SearchByEmotionPopUp/SearchByEmotionPopUp';
 
 export default function SearchByEmotion(){
-    const navigate=useNavigate();
-    const handleBackButton=()=>{
+    const navigate = useNavigate();
+
+    const handleBackButton = () => {
         navigate('/main');
     }
 

--- a/src/pages/SearchByEmotion/SearchByEmotionPopUp/SearchByEmotionPopUp.jsx
+++ b/src/pages/SearchByEmotion/SearchByEmotionPopUp/SearchByEmotionPopUp.jsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { useRecoilState } from "recoil";
 import { diaryListAtom } from "../../../recoil/atoms";
 import { useNavigate } from "react-router-dom";
-import { usePostFeelingList } from "../../../hooks/queries/mypage/usePostFeelingList";
+import usePostFeelingList from "../../../hooks/queries/mypage/usePostFeelingList";
 import { useModal } from '../../../hooks/common/useModal';
 import DiaryErrorModal from '../../../components/Modal/DiaryErrorModal';
 import BtnEmotionType from '../../../components/common/buttons/EmotionType/EmotionType';
@@ -12,7 +12,7 @@ export default function SearchByEmotionPopUp(){
   const [diaryList, setDiaryList] = useRecoilState(diaryListAtom);
   const [errorMessage, setErrorMessage] = useState('');
   const [isOpen, openModal, closeModal] = useModal();
-  const { mutation } = usePostFeelingList();
+  const mutation = usePostFeelingList();
   const navigate = useNavigate();
   
   const handleClick = (btnEnum) => {

--- a/src/pages/SearchByEmotion/SearchByEmotionPopUp/SearchByEmotionPopUp.jsx
+++ b/src/pages/SearchByEmotion/SearchByEmotionPopUp/SearchByEmotionPopUp.jsx
@@ -1,12 +1,12 @@
 import * as S from './SearchByEmotionPopUp.style';
 import { useRecoilState } from "recoil";
-import { diaryList } from "../../../recoil/atoms";
+import { diaryListAtom } from "../../../recoil/atoms";
 import { useNavigate } from "react-router-dom";
 import { usePostFeelingList } from "../../../hooks/queries/mypage/usePostFeelingList";
 import BtnEmotionType from '../../../components/common/buttons/EmotionType/EmotionType';
 
 export default function SearchByEmotionPopUp(){
-  const [diaryListAtom, setDiaryListAtom] = useRecoilState(diaryList);
+  const [diaryList, setDiaryList] = useRecoilState(diaryListAtom);
   const { mutation } = usePostFeelingList();
   const navigate = useNavigate();
   
@@ -18,7 +18,7 @@ export default function SearchByEmotionPopUp(){
     mutation.mutate(body, {
       onSuccess: (response) => {
         console.log(response);
-        setDiaryListAtom(response.data.feelingList);    
+        setDiaryList(response.data.feelingList);    
         navigate('/searchbyemotion/diarylist');
       }
     });

--- a/src/pages/SearchByEmotion/SearchByEmotionPopUp/SearchByEmotionPopUp.jsx
+++ b/src/pages/SearchByEmotion/SearchByEmotionPopUp/SearchByEmotionPopUp.jsx
@@ -1,21 +1,73 @@
 import * as S from './SearchByEmotionPopUp.style';
+import { useRecoilState } from "recoil";
+import { diaryList } from "../../../recoil/atoms";
+import { useNavigate } from "react-router-dom";
+import { usePostFeelingList } from "../../../hooks/queries/mypage/usePostFeelingList";
 import BtnEmotionType from '../../../components/common/buttons/EmotionType/EmotionType';
 
 export default function SearchByEmotionPopUp(){
-    return(
-        <S.Wrapper>
-            <S.SearchByEmotionPopUpWrapper1>
-                <BtnEmotionType name='기쁨' btnEnum="HAPPY"/>
-                <BtnEmotionType name='분노' btnEnum="ANGRY"/>
-                <BtnEmotionType name='평온' btnEnum="RELAX"/>
-            </S.SearchByEmotionPopUpWrapper1>
+  const [diaryListAtom, setDiaryListAtom] = useRecoilState(diaryList);
+  const { mutation } = usePostFeelingList();
+  const navigate = useNavigate();
+  
+  const handleClick = (btnEnum) => {
+    const body = {
+      feeling : btnEnum,
+    };
 
-            <S.SearchByEmotionPopUpWrapper2>
-                <BtnEmotionType name='슬픔' btnEnum="SAD"/>
-                <BtnEmotionType name='걱정' btnEnum="WORRIED"/>
-                <BtnEmotionType name='놀람' btnEnum="SURPRISED"/>
-            </S.SearchByEmotionPopUpWrapper2>
-        </S.Wrapper>
-        
-    )
+    mutation.mutate(body, {
+      onSuccess: (response) => {
+        console.log(response);
+        setDiaryListAtom(response.data.feelingList);    
+        navigate('/searchbyemotion/diarylist');
+      }
+    });
+  };
+
+  return(
+    <S.Wrapper>
+      <S.SearchByEmotionPopUpWrapper1>
+        <BtnEmotionType 
+          name = '기쁨'
+          onClick = {() => {
+            handleClick('HAPPY');
+          }}
+        />
+        <BtnEmotionType 
+          name = '분노'
+          onClick = {() => {
+            handleClick('ANGRY');
+          }}
+        />
+        <BtnEmotionType 
+          name = '평온'
+          onClick = {() => {
+            handleClick('RELAX');
+          }}
+        />
+      </S.SearchByEmotionPopUpWrapper1>
+
+      <S.SearchByEmotionPopUpWrapper2>
+      <BtnEmotionType 
+          name = '슬픔'
+          onClick = {() => {
+            handleClick('SAD');
+          }}
+        />
+        <BtnEmotionType 
+          name = '걱정'
+          onClick = {() => {
+            handleClick('WORRIED');
+          }}
+        />
+        <BtnEmotionType 
+          name = '놀람'
+          onClick = {() => {
+            handleClick('SURPRISED');
+          }}
+        />
+      </S.SearchByEmotionPopUpWrapper2>
+    </S.Wrapper>
+      
+  )
 }

--- a/src/pages/SearchByEmotion/SearchByEmotionPopUp/SearchByEmotionPopUp.jsx
+++ b/src/pages/SearchByEmotion/SearchByEmotionPopUp/SearchByEmotionPopUp.jsx
@@ -1,6 +1,5 @@
-import * as S from './SearchByEmotionPopUp.style'
-import BtnEmotionType from '../../../components/common/buttons/EmotionType/EmotionType'
-
+import * as S from './SearchByEmotionPopUp.style';
+import BtnEmotionType from '../../../components/common/buttons/EmotionType/EmotionType';
 
 export default function SearchByEmotionPopUp(){
     return(

--- a/src/pages/SearchByEmotion/SearchByEmotionPopUp/SearchByEmotionPopUp.jsx
+++ b/src/pages/SearchByEmotion/SearchByEmotionPopUp/SearchByEmotionPopUp.jsx
@@ -1,12 +1,17 @@
 import * as S from './SearchByEmotionPopUp.style';
+import { useState } from 'react';
 import { useRecoilState } from "recoil";
 import { diaryListAtom } from "../../../recoil/atoms";
 import { useNavigate } from "react-router-dom";
 import { usePostFeelingList } from "../../../hooks/queries/mypage/usePostFeelingList";
+import { useModal } from '../../../hooks/common/useModal';
+import DiaryErrorModal from '../../../components/Modal/DiaryErrorModal';
 import BtnEmotionType from '../../../components/common/buttons/EmotionType/EmotionType';
 
 export default function SearchByEmotionPopUp(){
   const [diaryList, setDiaryList] = useRecoilState(diaryListAtom);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [isOpen, openModal, closeModal] = useModal();
   const { mutation } = usePostFeelingList();
   const navigate = useNavigate();
   
@@ -17,15 +22,27 @@ export default function SearchByEmotionPopUp(){
 
     mutation.mutate(body, {
       onSuccess: (response) => {
-        console.log(response);
         setDiaryList(response.data.feelingList);    
         navigate('/searchbyemotion/diarylist');
+      },
+      onError: (error) => {
+        setErrorMessage(error.response.data.message);
+        console.log(errorMessage);
+        openModal();
       }
     });
   };
 
   return(
     <S.Wrapper>
+      {isOpen && 
+        <DiaryErrorModal 
+          closeModal = {closeModal} 
+          top = '50%'
+        >
+          {errorMessage}
+        </DiaryErrorModal>
+      }
       <S.SearchByEmotionPopUpWrapper1>
         <BtnEmotionType 
           name = '기쁨'

--- a/src/recoil/atoms.js
+++ b/src/recoil/atoms.js
@@ -81,7 +81,7 @@ export const diaryAdvice = atom({
     effects_UNSTABLE: [persistAtom]
 });
 
-export const diaryList = atom({
+export const diaryListAtom = atom({
     key: 'diaryList',
     default: {},
     effects_UNSTABLE: [persistAtom],

--- a/src/recoil/atoms.js
+++ b/src/recoil/atoms.js
@@ -84,4 +84,5 @@ export const diaryAdvice = atom({
 export const diaryList = atom({
     key: 'diaryList',
     default: {},
+    effects_UNSTABLE: [persistAtom],
 })

--- a/src/recoil/atoms.js
+++ b/src/recoil/atoms.js
@@ -80,3 +80,8 @@ export const diaryAdvice = atom({
     },
     effects_UNSTABLE: [persistAtom]
 });
+
+export const diaryList = atom({
+    key: 'diaryList',
+    default: {},
+})


### PR DESCRIPTION
## Related Issue 🍫

- close : #73 

## Summary 🍪

- usePostFeeling 을 통하여 감정별 일기 리스트를 받아옵니다.
- PopUp 컴포넌트에서 handleClick 함수를 구현하여 api 연결 및 atom 값 저장 후 navigate를 하도록 하였습니다. handleClick 함수를 onClick의 props가 되도록 로직을 수정하였습니다.
- DiaryList 컴포넌트에서 atom값을 토대로 diaryLsit를 나열합니다. 
- 뒤로가기 버튼을 누를 시 atom 값은 초기화됩니다. 
- DiaryErrorModal을 수정하여 컴포넌트의 재사용성과 범용성을 높였습니다. 이를 이용하여 api 연결 실패시 onError를 통해 모달창을 띄우도록 하였습니다.

## Before i request PR review 🍰

- 수월하게 진해되어서 다행인 것 같습니다!!!!
- 시간이 된다면,,,,버튼 컴포넌트도 조금 수정하여 머지하겠습니다
- 감사합니다!


https://github.com/KAU2024-SANHAK/SANHAK_Client/assets/104068583/17d94730-f125-4784-9a08-a31b1ea501f3


