### PR TITLE
[refactor] 마이페이지, 감정별 조회 페이지, 느린 일기, 빠른 일기 페이지 스타일 수정 

### DIFF
--- a/src/components/DiaryProgress/DiaryProgress.style.js
+++ b/src/components/DiaryProgress/DiaryProgress.style.js
@@ -1,5 +1,4 @@
 import styled from 'styled-components'
 
 export const Wrapper = styled.div`
-    margin-right: 3rem;
 `

--- a/src/components/FastDiarySteps/FastDiaryStep.style.js
+++ b/src/components/FastDiarySteps/FastDiaryStep.style.js
@@ -7,12 +7,19 @@ export const FastDiaryStepWrapper = styled.div`
   height: 36.5rem;
 `;
 export const ButtonField = styled.div`
-${({ theme: { mixin } }) => mixin.flexBox({ justify: 'space-between', align: 'center' })};
+  ${({ theme: { mixin } }) => mixin.flexBox({ justify: 'space-between', align: 'center' })};
   width: 37.5rem;
   position: absolute;
   bottom: 0.5rem;
   padding: 0 2.5rem 0 2.5rem;
 `;
+export const Step1ButtonField = styled.div`
+  ${({ theme: { mixin } }) => mixin.flexBox({ justify: 'flex-end'})};
+  width: 37.5rem;
+  position: absolute;
+  bottom: 0.9rem;
+  padding: 0 2.5rem 0 2.5rem;
+`
 
 export const QuestionWrapper = styled.div`
   ${({ theme: { mixin } }) => mixin.flexCenter({})};

--- a/src/components/FastDiarySteps/FastDiaryStep.style.js
+++ b/src/components/FastDiarySteps/FastDiaryStep.style.js
@@ -4,7 +4,7 @@ import inputCloud from '../../assets/InputCloud.png';
 export const FastDiaryStepWrapper = styled.div`
   ${({ theme: { mixin } }) => mixin.flexBox({ direction: 'column', align: 'center' })};
   width: 100%;
-  height: 100%;
+  height: 36.5rem;
 `;
 export const ButtonField = styled.div`
   display: flex;
@@ -18,7 +18,8 @@ export const ButtonField = styled.div`
 `;
 
 export const QuestionWrapper = styled.div`
-${({ theme: { mixin } }) => mixin.flexCenter({})};
+  ${({ theme: { mixin } }) => mixin.flexCenter({})};
+
   width: 100%;
   gap: 1.6rem;
 `;

--- a/src/components/FastDiarySteps/FastDiaryStep.style.js
+++ b/src/components/FastDiarySteps/FastDiaryStep.style.js
@@ -18,10 +18,7 @@ export const ButtonField = styled.div`
 `;
 
 export const QuestionWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-content: space-between;
+${({ theme: { mixin } }) => mixin.flexCenter({})};
   width: 100%;
   gap: 1.6rem;
 `;

--- a/src/components/FastDiarySteps/FastDiaryStep.style.js
+++ b/src/components/FastDiarySteps/FastDiaryStep.style.js
@@ -7,14 +7,11 @@ export const FastDiaryStepWrapper = styled.div`
   height: 36.5rem;
 `;
 export const ButtonField = styled.div`
-  display: flex;
-  width: 100%;
+${({ theme: { mixin } }) => mixin.flexBox({ justify: 'space-between', align: 'center' })};
+  width: 37.5rem;
   position: absolute;
   bottom: 0.5rem;
-  padding: 0 2rem;
-  justify-content: flex-end;
-  align-items: center;
-  margin-top: 10.8rem;
+  padding: 0 2.5rem 0 2.5rem;
 `;
 
 export const QuestionWrapper = styled.div`

--- a/src/components/FastDiarySteps/FastDiaryStep1.jsx
+++ b/src/components/FastDiarySteps/FastDiaryStep1.jsx
@@ -12,9 +12,9 @@ export default function FastDiaryStep1({onNext}){
 
       <FeelingHive/>
       
-      <S.ButtonField>
+      <S.Step1ButtonField>
         <BtnNext onNext={onNext}/>
-      </S.ButtonField>
+      </S.Step1ButtonField>
     </S.FastDiaryStepWrapper>
   );
 }

--- a/src/components/FastDiarySteps/FeelingHive/FeelingHive.style.js
+++ b/src/components/FastDiarySteps/FeelingHive/FeelingHive.style.js
@@ -23,4 +23,5 @@ export const ThirdLayer = styled.div`
 `;
 export const HoneyPotWrapper = styled.div`
   margin-top: 1rem;
+  padding-left: 0.5rem;
 `;

--- a/src/components/FastDiarySteps/Questions/LargeQustion.jsx
+++ b/src/components/FastDiarySteps/Questions/LargeQustion.jsx
@@ -2,10 +2,8 @@ import * as S from './Question.style';
 
 export default function LargeQuestion({ children }) {
   return (
-    <S.LargeQuestionWrapper>
       <S.LargeQuestionPng>
         <S.QuestionText>{children}</S.QuestionText>
       </S.LargeQuestionPng>
-    </S.LargeQuestionWrapper>
   );
 }

--- a/src/components/FastDiarySteps/Questions/Question.style.js
+++ b/src/components/FastDiarySteps/Questions/Question.style.js
@@ -2,18 +2,12 @@ import styled from 'styled-components';
 import smallSpeakCloud from '../../../assets/smallSpeakCloud.png';
 import largeSpeakCloud from '../../../assets/largeSpeakCloud.png';
 
-export const SmallQuestionWrapper = styled.div`
-  width: 100%;
-`;
-
 export const SmallQuestionPng = styled.div`
   background-image: url(${smallSpeakCloud});
   width: 34rem;
   height: 7.5rem;
 `;
-export const LargeQuestionWrapper = styled.div`
-  width: 100%;
-`;
+
 export const LargeQuestionPng = styled.div`
   background-image: url(${largeSpeakCloud});
   width: 34rem;
@@ -23,5 +17,5 @@ export const QuestionText = styled.p`
   ${({ theme: { mixin } }) => mixin.flexCenter({})};
   ${({ theme }) => theme.fonts.heading_03};
   width: 100%;
-  padding-top: 3rem;
+  padding-top: 2.7rem;
 `;

--- a/src/components/FastDiarySteps/Questions/SamllQuestion.jsx
+++ b/src/components/FastDiarySteps/Questions/SamllQuestion.jsx
@@ -2,10 +2,8 @@ import * as S from './Question.style';
 
 export default function SmallQuestion({ children }) {
   return (
-    <S.SmallQuestionWrapper>
       <S.SmallQuestionPng>
         <S.QuestionText>{children}</S.QuestionText>
       </S.SmallQuestionPng>
-    </S.SmallQuestionWrapper>
   );
 }

--- a/src/components/common/buttons/Home/BtnHome.style.js
+++ b/src/components/common/buttons/Home/BtnHome.style.js
@@ -2,9 +2,8 @@ import styled from 'styled-components'
 import { IcHome } from '../../../../assets/svg'
 
 export const ButtonWrapper = styled.button`
-    position: absolute;
-    left: 2rem;
     background-color: transparent;
+    
 `
 export const HomeButton = styled(IcHome)`
     display: flex;

--- a/src/components/common/buttons/Prev/BtnPrev.style.js
+++ b/src/components/common/buttons/Prev/BtnPrev.style.js
@@ -2,10 +2,8 @@ import styled from 'styled-components'
 import { IcPrevButton } from '../../../../assets/svg'
 
 export const ButtonWrapper = styled.button`
-    display: flex;
-    position: absolute;
     background-color: transparent;
-    left: 4rem;
+    padding-top: 0.7rem;
 `
 export const PrevButton = styled(IcPrevButton)`
     display: flex;

--- a/src/components/common/buttons/ThisMonthEmotion/ThisMonthEmotion.style.js
+++ b/src/components/common/buttons/ThisMonthEmotion/ThisMonthEmotion.style.js
@@ -23,12 +23,12 @@ export const ThisMonthEmotionText = styled.p`
     width: 17.8rem;
     padding-top: 1.2rem;
     text-align: center;
-
 `
 export const PlayList = styled.p`
     margin-left: 3.9rem;
     margin-top: 0.8rem;
     ${({ theme }) => theme.fonts.caption_01};
+    cursor: pointer;
 `
 export const HoneyBearWrapper = styled.div`
     width: 10rem;

--- a/src/pages/DiaryList/DiaryList.sytle.js
+++ b/src/pages/DiaryList/DiaryList.sytle.js
@@ -7,7 +7,6 @@ export const DiaryListWrapper=styled.div`
     min-height: 100vh;
     height: auto;
     max-height: fit-content;
-    justify-content: start;
 `
 export const BackButtonWrapper = styled.div`
     ${({ theme: { mixin } }) => mixin.flexBox({})};

--- a/src/pages/DiaryView/DiaryView.jsx
+++ b/src/pages/DiaryView/DiaryView.jsx
@@ -90,14 +90,14 @@ export default function DiaryView() {
         }
         <S.DiaryCompWrapper>
           <S.HeaderWrapper>
-            <S.BtnBackWrapper>
-              <BtnBack handleClick={handleBack} />
-            </S.BtnBackWrapper>
+            <BtnBack handleClick={handleBack} />
+            
             <S.ExtraBtnWrapper>
               <BtnShare title={title} image={image} id={id}/>
               <BtnMenu openModal={openModal}/>
             </S.ExtraBtnWrapper>
           </S.HeaderWrapper>
+
           <S.CreatedDiaryWrapper>
             <CreatedDiary
               title={title}  

--- a/src/pages/DiaryView/DiaryView.style.js
+++ b/src/pages/DiaryView/DiaryView.style.js
@@ -12,22 +12,17 @@ export const DiaryViewPageWrapper=styled.div`
     justify-content: space-between;
 `
 export const DiaryCompWrapper = styled.div`
-    width: 100%;
+    width: 32rem;
 `
 export const HeaderWrapper = styled.div`
     ${({ theme: { mixin } }) => mixin.flexBox({})};
-    width: 100%;
+    width: 32rem;
     margin-top: 3.2rem;
     justify-content: space-between;
 `
-export const BtnBackWrapper = styled.div`
-    padding-left: 2rem;
-    
-`
+
 export const ExtraBtnWrapper = styled.div`
     ${({ theme: { mixin } }) => mixin.flexCenter({direction:'row'})};
-    background-color: transparent;
-    padding-right: 2rem;
 `
 export const CreatedDiaryWrapper = styled.div`
     ${({ theme: { mixin } }) => mixin.flexCenter({})};

--- a/src/pages/FastDiary/FastDiary.jsx
+++ b/src/pages/FastDiary/FastDiary.jsx
@@ -93,14 +93,21 @@ export default function FastDiary() {
       )}
 
       <S.FastDiaryHeader>
-        <BtnHome
-          onClick={() => {
-            openModal();
-          }}
-        />
+        <S.HomeButtonWrapper>
+          <BtnHome
+              onClick={() => {
+                openModal();
+              }}
+            />
+        </S.HomeButtonWrapper>
 
         <DiaryProgress steps={steps} cur={currentStep} />
       </S.FastDiaryHeader>
+
+      <S.HoneyBearWrapper>
+        <S.HoneyBear height='30rem' />
+      </S.HoneyBearWrapper>
+
       <S.WritingWrapper>
         <S.WritingForm>
           <Funnel>
@@ -121,9 +128,6 @@ export default function FastDiary() {
             ))}
           </Funnel>
         </S.WritingForm>
-        <S.HoneyBearWrapper>
-          <S.HoneyBear height='30.5rem' />
-        </S.HoneyBearWrapper>
       </S.WritingWrapper>
     </S.FastDairyPageWrapper>
   );

--- a/src/pages/FastDiary/FastDiary.style.js
+++ b/src/pages/FastDiary/FastDiary.style.js
@@ -19,10 +19,10 @@ export const FastDiaryHeader = styled.div`
 
 export const WritingForm = styled.div`
   ${({ theme: { mixin } }) => mixin.flexCenter({})};
-
   width: 100%;
   padding: 2.4rem 1.5rem 0 1.5rem;
   border-radius: 3rem;
+
   background: rgba(255, 255, 255, 0.5);
   -webkit-backdrop-filter: blur(1.5rem);
   -moz-backdrop-filter: blur(1.5rem);
@@ -36,7 +36,7 @@ export const WritingWrapper = styled.div`
   display: flex;
   bottom: 0;
   width: 100%;
-  height: 44rem;
+  height: 43.4rem;
 `;
 
 export const HoneyBearWrapper = styled.div`

--- a/src/pages/FastDiary/FastDiary.style.js
+++ b/src/pages/FastDiary/FastDiary.style.js
@@ -34,9 +34,8 @@ export const WritingForm = styled.div`
 
 export const WritingWrapper = styled.div`
   display: flex;
-  position: absolute;
   bottom: 0;
-  width: 37.5rem;
+  width: 100%;
   height: 44rem;
 `;
 

--- a/src/pages/FastDiary/FastDiary.style.js
+++ b/src/pages/FastDiary/FastDiary.style.js
@@ -12,15 +12,15 @@ export const FastDairyPageWrapper = styled.div`
       : ({ theme }) => theme.colors.gradient.gradient_yellow};
 `;
 export const FastDiaryHeader = styled.div`
-  ${({ theme: { mixin } }) => mixin.flexBox({ justify: 'flex-end' })}
-  width: 100%;
-  margin-top: 3.2rem;
+  ${({ theme: { mixin } }) => mixin.flexBox({ justify: 'space-between', align: 'center' })}
+  width: 32rem;
+  height: 25rem;
 `;
+
 export const WritingForm = styled.div`
   ${({ theme: { mixin } }) => mixin.flexCenter({})};
 
   width: 100%;
-  height: 43.1rem;
   padding: 2.4rem 1.5rem 0 1.5rem;
   border-radius: 3rem;
   background: rgba(255, 255, 255, 0.5);
@@ -34,24 +34,25 @@ export const WritingForm = styled.div`
 
 export const WritingWrapper = styled.div`
   display: flex;
-  width: 100%;
-  height: fit-content;
-`;
-export const HomeButtonWrapper = styled.div`
-  border: none;
-  background: transparent;
-  margin-left: 2rem;
-  margin-bottom: 10rem;
+  position: absolute;
+  bottom: 0;
+  width: 37.5rem;
 `;
 
 export const HoneyBearWrapper = styled.div`
-  width: 100%;
+  ${({ theme: { mixin } }) => mixin.flexBox({justify:'start'})};
+  width: 37.5rem;
   position: absolute;
+  height: 30rem;
   top: 13rem;
-  right: 5.5rem;
 `;
 export const HoneyBear = styled(IcHoneyBear)``;
+
 export const ProgressWrapper = styled.div`
   ${({ theme: { mixin } }) => mixin.flexBox({ align: 'flex-end' })};
   bottom: 0;
 `;
+
+export const HomeButtonWrapper = styled.div`
+  padding-bottom: 12rem;
+`

--- a/src/pages/FastDiary/FastDiary.style.js
+++ b/src/pages/FastDiary/FastDiary.style.js
@@ -37,6 +37,7 @@ export const WritingWrapper = styled.div`
   position: absolute;
   bottom: 0;
   width: 37.5rem;
+  height: 44rem;
 `;
 
 export const HoneyBearWrapper = styled.div`

--- a/src/pages/MyPage/MyPage.jsx
+++ b/src/pages/MyPage/MyPage.jsx
@@ -13,12 +13,9 @@ export default function MyPage(){
   return(
     <S.MyPageWrapper>
       <S.TopWrapper>
-        <S.BackButtonWrapper>
           <BtnBack 
             handleClick={handleBackButton}
           />
-        </S.BackButtonWrapper>
-        
         <S.HoneyBearWrapper>
           <S.HoneyBear 
             height='30rem'

--- a/src/pages/MyPage/MyPage.jsx
+++ b/src/pages/MyPage/MyPage.jsx
@@ -13,9 +13,9 @@ export default function MyPage(){
   return(
     <S.MyPageWrapper>
       <S.TopWrapper>
-          <BtnBack 
-            handleClick={handleBackButton}
-          />
+        <BtnBack 
+          handleClick={handleBackButton}
+        />
         <S.HoneyBearWrapper>
           <S.HoneyBear 
             height='30rem'

--- a/src/pages/MyPage/MyPage.style.js
+++ b/src/pages/MyPage/MyPage.style.js
@@ -23,9 +23,9 @@ export const HoneyBear = styled(IcHoneyBear)`
     display: flex;
 `
 export const BackButtonWrapper = styled.div`
-    padding-left: 2.8rem;
-    padding-top: 3.2rem;
-    z-index: 1;
+    ${({ theme: { mixin } }) => mixin.flexBox({})};
+    width: 32rem;
+    margin-top: 3.2rem;
 `
 export const PopUpWrapper = styled.div`
     ${({ theme: { mixin } }) => mixin.flexCenter({})};

--- a/src/pages/MyPage/MyPage.style.js
+++ b/src/pages/MyPage/MyPage.style.js
@@ -9,8 +9,10 @@ export const MyPageWrapper=styled.div`
     justify-content: space-between;
 `
 export const TopWrapper = styled.div`
-    width: 100%;
+    width: 32rem;
     height: 20rem;
+    margin-top: 3.2rem;
+
 `
 export const HoneyBearWrapper = styled.div`
     ${({ theme: { mixin } }) => mixin.flexCenter({})};
@@ -21,11 +23,6 @@ export const HoneyBearWrapper = styled.div`
 `
 export const HoneyBear = styled(IcHoneyBear)`
     display: flex;
-`
-export const BackButtonWrapper = styled.div`
-    ${({ theme: { mixin } }) => mixin.flexBox({})};
-    width: 32rem;
-    margin-top: 3.2rem;
 `
 export const PopUpWrapper = styled.div`
     ${({ theme: { mixin } }) => mixin.flexCenter({})};

--- a/src/pages/SearchByEmotion/SearchByEmotion.jsx
+++ b/src/pages/SearchByEmotion/SearchByEmotion.jsx
@@ -14,9 +14,7 @@ export default function SearchByEmotion(){
   return(
     <S.MyPageWrapper>
       <S.TopWrapper>
-        <S.BackButtonWrapper>
-          <BtnBack handleClick={handleBackButton} />
-        </S.BackButtonWrapper>
+        <BtnBack handleClick={handleBackButton} />
         
         <S.HoneyBearWrapper>
           <S.HoneyBear height='30rem' />

--- a/src/pages/SearchByEmotion/SearchByEmotion.jsx
+++ b/src/pages/SearchByEmotion/SearchByEmotion.jsx
@@ -5,31 +5,30 @@ import BtnBack from '../../components/common/buttons/Back/BtnBack';
 import SearchByEmotionPopUp from './SearchByEmotionPopUp/SearchByEmotionPopUp';
 
 export default function SearchByEmotion(){
-    const navigate = useNavigate();
+  const navigate = useNavigate();
 
-    const handleBackButton = () => {
+  const handleBackButton = () => {
+    navigate('/main');
+  }
+
+  return(
+    <S.MyPageWrapper>
+      <S.TopWrapper>
+        <S.BackButtonWrapper>
+          <BtnBack handleClick={handleBackButton} />
+        </S.BackButtonWrapper>
         
-        navigate('/main');
-    }
-
-    return(
-        <S.MyPageWrapper>
-            <S.TopWrapper>
-                <S.BackButtonWrapper>
-                    <BtnBack handleClick={handleBackButton}/>
-                </S.BackButtonWrapper>
-                
-                <S.HoneyBearWrapper>
-                    <S.HoneyBear height='30rem'/>
-                </S.HoneyBearWrapper>
-            </S.TopWrapper>
-            
-            <S.PopUpWrapper>
-                <PopUp name='감정별 일기조회'>
-                    <SearchByEmotionPopUp/>
-                </PopUp>
-            </S.PopUpWrapper>
-            
-        </S.MyPageWrapper>
-    )
+        <S.HoneyBearWrapper>
+          <S.HoneyBear height='30rem' />
+        </S.HoneyBearWrapper>
+      </S.TopWrapper>
+      
+      <S.PopUpWrapper>
+        <PopUp name='감정별 일기조회'>
+          <SearchByEmotionPopUp/>
+        </PopUp>
+      </S.PopUpWrapper>
+        
+    </S.MyPageWrapper>
+  )
 }

--- a/src/pages/SearchByEmotion/SearchByEmotion.style.js
+++ b/src/pages/SearchByEmotion/SearchByEmotion.style.js
@@ -9,7 +9,7 @@ export const MyPageWrapper=styled.div`
     justify-content: space-between;
 `
 export const TopWrapper = styled.div`
-    width: 100%;
+    width: 32rem;
     height: 20rem;
 `
 export const HoneyBearWrapper = styled.div`
@@ -23,9 +23,8 @@ export const HoneyBear = styled(IcHoneyBear)`
     display: flex;
 `
 export const BackButtonWrapper = styled.div`
-    padding-left: 2.8rem;
+    ${({ theme: { mixin } }) => mixin.flexBox({align:'center', justify:'start'})};
     padding-top: 3.2rem;
-    z-index: 1;
 `
 export const PopUpWrapper = styled.div`
     ${({ theme: { mixin } }) => mixin.flexCenter({})};

--- a/src/pages/SearchByEmotion/SearchByEmotion.style.js
+++ b/src/pages/SearchByEmotion/SearchByEmotion.style.js
@@ -11,6 +11,7 @@ export const MyPageWrapper=styled.div`
 export const TopWrapper = styled.div`
     width: 32rem;
     height: 20rem;
+    margin-top: 3.2rem;
 `
 export const HoneyBearWrapper = styled.div`
     ${({ theme: { mixin } }) => mixin.flexCenter({})};
@@ -21,10 +22,6 @@ export const HoneyBearWrapper = styled.div`
 `
 export const HoneyBear = styled(IcHoneyBear)`
     display: flex;
-`
-export const BackButtonWrapper = styled.div`
-    ${({ theme: { mixin } }) => mixin.flexBox({align:'center', justify:'start'})};
-    padding-top: 3.2rem;
 `
 export const PopUpWrapper = styled.div`
     ${({ theme: { mixin } }) => mixin.flexCenter({})};

--- a/src/pages/SlowDiary/SlowDiary.jsx
+++ b/src/pages/SlowDiary/SlowDiary.jsx
@@ -5,7 +5,6 @@ import { useFileReader } from '../../hooks/common/useFileReader';
 import { useNavigate } from 'react-router-dom';
 import { diaryImage, diaryContent, diaryTitle, diaryId, createdDate } from '../../recoil/atoms';
 import { useRecoilState } from 'recoil';
-// import parse from 'html-react-parser';
 import usePostSlowDiary from '../../hooks/queries/slowdiary/usePostSlowDiary';
 import usePatchDiary from '../../hooks/queries/slowdiary/usePatchDiary';
 import BtnHome from '../../components/common/buttons/Home/BtnHome';

--- a/src/pages/SlowDiary/SlowDiary.style.js
+++ b/src/pages/SlowDiary/SlowDiary.style.js
@@ -4,7 +4,7 @@ import SvgIcAddImage from '../../assets/svg/IcAddImage';
 export const SlowDiaryPageWrapper = styled.div`
     ${({ theme: { mixin } }) => mixin.flexCenter({})};
     width: 100%;
-    height: 92.2rem;
+    min-height: 100vh;
     background: ${(props) => (props.$isEven === 0 ? 'linear-gradient(187deg, #FFBBCB 20.43%, #FFDAE3 81.25%, #DCC6CC 100.45%, #999 100.45%);'
     :'linear-gradient(187deg, #FFE768 20.43%, #FFF3B7 84.05%);'
     )};
@@ -12,7 +12,8 @@ export const SlowDiaryPageWrapper = styled.div`
 `
 export const SlowDiaryHeader = styled.div`
     width: 32rem;
-    position: relative;
+    height: 16rem;
+    padding-top: 4rem;
 `
 export const FormWrapper = styled.form`
     ${({ theme: { mixin } }) => mixin.flexCenter({})};
@@ -87,6 +88,7 @@ export const BtnField = styled.div`
     ${({ theme: { mixin } }) => mixin.flexBox({justify:'flex-end'})};
     width: 32rem;
     padding-top: 1.8rem;
+    padding-bottom: 1rem;
 `
 
 export const Caption =styled.p`
@@ -95,8 +97,7 @@ export const Caption =styled.p`
     letter-spacing: -0.0408rem;
     
     margin-bottom: 0.5rem;
-    margin-top: 9rem;
-    margin-left: 8.5rem;
+    margin-left: 7.6rem;
     
 `
 export const PreviewImg = styled.img`

--- a/src/pages/SlowDiary/SlowDiary.style.js
+++ b/src/pages/SlowDiary/SlowDiary.style.js
@@ -11,10 +11,8 @@ export const SlowDiaryPageWrapper = styled.div`
 
 `
 export const SlowDiaryHeader = styled.div`
-    width:100%;
-    display: flex;
+    width: 32rem;
     position: relative;
-    top: 0;
 `
 export const FormWrapper = styled.form`
     ${({ theme: { mixin } }) => mixin.flexCenter({})};

--- a/src/pages/SlowDiary/SlowDiary.style.js
+++ b/src/pages/SlowDiary/SlowDiary.style.js
@@ -84,13 +84,11 @@ export const ContentInput = styled.textarea`
     }
 `
 export const BtnField = styled.div`
-    display: flex;    
-    width: 100%;
-    justify-content: flex-end;
+    ${({ theme: { mixin } }) => mixin.flexBox({justify:'flex-end'})};
+    width: 32rem;
     padding-top: 1.8rem;
-    padding-right: 2.8rem;
-
 `
+
 export const Caption =styled.p`
     ${({ theme }) => theme.fonts.body_10};
     color: ${({ theme }) => theme.colors.gray.text_gray};

--- a/src/recoil/atoms.js
+++ b/src/recoil/atoms.js
@@ -1,6 +1,5 @@
 import { atom } from "recoil";
 import { recoilPersist } from "recoil-persist";
-import defaultImage from '../assets/img/dayHoneyBear.webp';
 
 const { persistAtom } =recoilPersist({
    key: 'localstorage',
@@ -81,7 +80,7 @@ export const diaryFeeling = atom({
 
 export const diaryImage = atom({
     key: "diaryImage",
-    default: defaultImage,
+    default: '',
     effects_UNSTABLE: [persistAtom]
 });
 


### PR DESCRIPTION
## Related Issue 🍫

- close : #167 

## Summary 🍪

- 메인페이지 플리 추천 태그에 cursor: pointer 추가 (QA 반영)
- 모바일 화면 안 깨지면서 웹 화면 튀어나오지 않도록 수정 (직접 보시죠!)

## Before i request PR review 🍰

- 한 번 건드려봤습니다...  HoneyBear 빼고는 width 랑 flex 값들만 조절해서 어떻게 나올 지 모르겠는데, 혹시 가능하시다면 branch 받아서 IOS 에서 안 깨지는지 확인해주시면 감사하겠습니다! 확인 받고 머지 진행하겠습니다!
- 메인페이지는 일단 놔뒀습니다..! 여기는 뭔가 건드렸다가 돌이킬 수 없을 것 같은 느낌이.....//
- 

https://github.com/KAU2024-SANHAK/SANHAK_Client/assets/104068583/cfe88a8f-c091-4eeb-b372-c635227c193a


https://github.com/KAU2024-SANHAK/SANHAK_Client/assets/104068583/d3487d9c-3d04-4805-ba29-2b8a4cf5d385


https://github.com/KAU2024-SANHAK/SANHAK_Client/assets/104068583/ec79fe53-4a39-4c3d-83ad-96675e40af1f

![image](https://github.com/KAU2024-SANHAK/SANHAK_Client/assets/104068583/dfb59022-7ff5-426d-a681-6ba56335254c)

![image](https://github.com/KAU2024-SANHAK/SANHAK_Client/assets/104068583/bd50e8ca-7aa4-4354-b205-4b4acb7fd00a)



