### PR TITLE
[refactor] ios에서 깨지는 폰트 수정

### DIFF
--- a/src/components/common/buttons/Menu/Menu.style.js
+++ b/src/components/common/buttons/Menu/Menu.style.js
@@ -13,7 +13,6 @@ export const MenuBtn = styled(IcMenu)`
 export const MenuWrapper = styled.div`
     ${({ theme: { mixin } }) => mixin.flexCenter({})};
     width: 13rem;
-    height: 10rem;
     background-color: white;
     border-radius: 3rem;
     position: absolute;
@@ -22,16 +21,16 @@ export const MenuWrapper = styled.div`
 export const EditBtn = styled.button`
     ${({ theme }) => theme.fonts.body_02};
     ${({ theme: { mixin } }) => mixin.flexCenter({})};
-    margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
+    margin: 0.5rem 1.7rem 0.5rem 1.7rem;
     background-color: transparent;
+    color: black;
 `
 export const DeleteBtn = styled.button`
     ${({ theme }) => theme.fonts.body_02};
     ${({ theme: { mixin } }) => mixin.flexCenter({})};
-    margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
+    margin: 0.5rem 1.7rem 0.5rem 1.7rem;
     background-color: transparent;
+    color: black;
 `
 export const ButtonField = styled.div`
     width: 37.5rem;

--- a/src/components/common/buttons/ShowAdvice/BtnShowAdvice.style.js
+++ b/src/components/common/buttons/ShowAdvice/BtnShowAdvice.style.js
@@ -13,4 +13,5 @@ export const ButtonWrapper = styled.button`
 `
 export const ButtonText = styled.p`
   ${({ theme }) => theme.fonts.caption_04};
+  color: black;
 `

--- a/src/components/common/buttons/ShowFeeling/BtnShowFeeling.style.js
+++ b/src/components/common/buttons/ShowFeeling/BtnShowFeeling.style.js
@@ -12,6 +12,7 @@ export const ButtonWrapper = styled.button`
 export const ButtonText = styled.p`
   ${({ theme }) => theme.fonts.body_10};
   text-decoration: underline;
+  color: black;
 `
 export const TT = styled.p`
   ${({ theme }) => theme.fonts.heading_01};

--- a/src/pages/SharedView/SharedView.jsx
+++ b/src/pages/SharedView/SharedView.jsx
@@ -68,16 +68,9 @@ export default function SharedView(){
           >
             허니어리 사용하기
           </BtnSubmit>
-          <BtnSubmit
-          onClick={() => {
-            handleGoInfo();
-          }}
-            width='11.6rem'
-            height='4rem'
-            $color = {({ theme }) => theme.colors.normal.white}
-          >
+          <S.infobtn onClick={() => {handleGoInfo()}}>
             허니어리란?
-          </BtnSubmit>
+          </S.infobtn>
         </S.ButtonField>
       </S.Header>
 

--- a/src/pages/SharedView/SharedView.style.js
+++ b/src/pages/SharedView/SharedView.style.js
@@ -74,3 +74,12 @@ export const CloseBtn = styled.div`
   left: 31.6rem;
 `
 export const XBtn = styled(IcXBtn)``
+export const infobtn = styled.button`
+  ${({ theme }) => theme.fonts.body_01};
+  background-color: white;
+  color: black;
+  border-radius: 3rem;
+  flex-shrink: 0;
+  height: 4rem;
+  margin: 0 1.7rem 0 1.7rem;
+`


### PR DESCRIPTION
## Related Issue 🍫

- close : #[166] IOS에서 깨지는 폰트 수정

## Summary 🍪

- 일기작성 완료 화면에서 감정 보러가기 버튼과 조언 생성하기 버튼 폰트 색상 조절 및 카카오톡 공유 화면에서 조언 보러가기 버튼 폰트 색상 조절
- 일기작성 완료 화면에서 메뉴 버튼 눌렀을 때 나오는 수정하기 삭제하기 버튼 폰트 색상 조절 및 줄바꿈 문제 해결
- 카카오톡 공유 화면에서 허니어리란? 텍스트 줄바꿈 일어나지 않도록

## Before i request PR review 🍰

- 코드리뷰로 확인 부탁하는 사항


문제화면
![image](https://github.com/KAU2024-SANHAK/SANHAK_Client/assets/162946302/a52b2036-0624-42e3-95c7-751d4e7b12ab)

![image](https://github.com/KAU2024-SANHAK/SANHAK_Client/assets/162946302/df8d7347-edb0-4df5-b484-7216845e3d82)
