### PR TITLE
[style] 허니어리 소개 페이지 style 수정

### DIFF
--- a/src/pages/Information/Information.jsx
+++ b/src/pages/Information/Information.jsx
@@ -35,18 +35,18 @@ export default function Information() {
         <S.InfoWrapper>
             <S.TopWrapper>
                 <S.Header>
-                    <S.HoneyBear height={70}/>
-                        <S.Title>
-                            꿀단지 서비스 <br />
-                            허니어리란?
-                        </S.Title>
-                    <S.HoneyBear height={70}/>
+                    <S.Subtitle>
+                        꿀같은 일상을 담는 일기서비스
+                    </S.Subtitle>
+                    <S.Title>
+                        허니어리 🍯
+                    </S.Title>
                 </S.Header>
                 <S.Body>
                     
 
                     {isBackgroundClick ? 
-                        <S.Statement>
+                        <S.FirstStatement>
                             <S.HonearyBackgroundBtn onClick={BackgroundNotClick}>
                                 허니어리 서비스의 배경
                             </S.HonearyBackgroundBtn>
@@ -60,25 +60,28 @@ export default function Information() {
                             <br />
                             <br />
                             부족하지만, 열심히 만들어 봤습니다. 앞으로 더 좋은 허니어리를 위해 꾸준히 노력하겠습니다 ! : )
-                        </S.Statement>
+                        </S.FirstStatement>
                     :
-                        <S.HonearyBackgroundBtn onClick={BackgroundClick}>
+                        <S.HonearyBackgroundBeforeClickBtn onClick={BackgroundClick}>
                             허니어리 서비스의 배경
-                        </S.HonearyBackgroundBtn>
+                        </S.HonearyBackgroundBeforeClickBtn>
                     }
 
                     {isGgulbeeClick ? 
-                        <S.Statement>
+                        <S.SecondStatement>
                             <S.GgulbeesStatementBtn onClick={GgulbeeNotClick}>
-                                팀원(꿀비들) 소개
+                                TEAM HONEYARY
                             </S.GgulbeesStatementBtn>
 
                             <S.GgulbeeInfoWrapper1>
-                                (팀장) 왕호은
+                                왕호은
+                                <S.IntroductionText>
+                                    Team Leader
+                                </S.IntroductionText>
                                 <S.format>
-                                    <S.GgulbeePhotooWrapper>
+                                    <S.GgulbeePhotoWrapper>
                                         <S.GgulbeePhoto src={photo1}/>
-                                    </S.GgulbeePhotooWrapper>
+                                    </S.GgulbeePhotoWrapper>
                                     <S.GgulbeeFromatStatement1>
                                         “꿀같은 하루를 담다 - 허니어리 🍯🐻” <br />
                                         제작을 맡은  꿀Bee팀장 왕호은이라고 합니다. 더 좋은 서비스를 위해 꾸준히 연구하고 있습니다. 피드백을 환영합니다!    
@@ -87,23 +90,29 @@ export default function Information() {
                             </S.GgulbeeInfoWrapper1>
 
                             <S.GgulbeeInfoWrapper2>
-                                (프론트) 송필수
+                                송필수
+                                <S.IntroductionText>
+                                    Frontend Engineer
+                                </S.IntroductionText>
                                 <S.format>
                                     <S.GgulbeeFromatStatement2>
                                         프론트엔드 맡은 항공대 소프트웨어학과 송필수 입니다. 부족한 실력이지만 열심히 만들었으니, 잘 사용해주시면 감사하겠습니다! &#60;pissssssu.tistory.com&#62;
                                     </S.GgulbeeFromatStatement2>
-                                    <S.GgulbeePhotooWrapper>
+                                    <S.GgulbeePhotoWrapper>
                                         <S.GgulbeePhoto src={photo2}/>
-                                    </S.GgulbeePhotooWrapper>
+                                    </S.GgulbeePhotoWrapper>
                                 </S.format>
                             </S.GgulbeeInfoWrapper2>
                             
                             <S.GgulbeeInfoWrapper1>
-                                (프론트) 성소민
+                                성소민
+                                <S.IntroductionText>
+                                    UX/UI Designer, Frontend Engineer
+                                </S.IntroductionText>
                                 <S.format>
-                                    <S.GgulbeePhotooWrapper>
+                                    <S.GgulbeePhotoWrapper>
                                         <S.GgulbeePhoto src={photo3}/>
-                                    </S.GgulbeePhotooWrapper>
+                                    </S.GgulbeePhotoWrapper>
                                     <S.GgulbeeFromatStatement1>
                                         UX/UI 디자인과 프론트엔드를 담당한 <br /> 항공대 스마트드론공학과 성소민입니다. 허니어리 서비스만의 개성있고, 힐링되는 UI 경험을 얻어가시면 좋겠습니다!
                                     </S.GgulbeeFromatStatement1>
@@ -111,23 +120,29 @@ export default function Information() {
                             </S.GgulbeeInfoWrapper1>
                             
                             <S.GgulbeeInfoWrapper2>
-                                (백엔드) 좌민석
+                                좌민석
+                                <S.IntroductionText>
+                                    Backend Engineer
+                                </S.IntroductionText>   
                                 <S.format>
                                     <S.GgulbeeFromatStatement2>
                                         안녕하세요 백엔드를 담당한 좌민석입니다! 사용자분들이 저희 허니어리를 통해서  자신의 하루를 소중히 간직할 수 있었으면 좋겠습니다 🤗
                                     </S.GgulbeeFromatStatement2>
-                                    <S.GgulbeePhotooWrapper>
+                                    <S.GgulbeePhotoWrapper>
                                         <S.GgulbeePhoto src={photo4}/>
-                                    </S.GgulbeePhotooWrapper>
+                                    </S.GgulbeePhotoWrapper>
                                 </S.format>
                             </S.GgulbeeInfoWrapper2>
                             
                             <S.GgulbeeInfoWrapper1>
-                                (AI) 송진학
+                                송진학
+                                <S.IntroductionText>
+                                    AI Engineer
+                                </S.IntroductionText>
                                 <S.format>
-                                    <S.GgulbeePhotooWrapper>
+                                    <S.GgulbeePhotoWrapper>
                                         <S.GgulbeePhoto src={photo5}/>
-                                    </S.GgulbeePhotooWrapper>
+                                    </S.GgulbeePhotoWrapper>
                                     <S.GgulbeeFromatStatement1>
                                         일기 자동완성, 감정 분석등 여러분이 사용하시게 될 기능들을 제작한 AI 담당 송진학입니다! <br />
                                         다양한 기능들 알차게 사용해주세요!
@@ -136,11 +151,11 @@ export default function Information() {
                             </S.GgulbeeInfoWrapper1>
                             
 
-                        </S.Statement>
+                        </S.SecondStatement>
                     :
-                        <S.GgulbeesStatementBtn onClick={GgulbeeClick}>
-                            팀원(꿀비들) 소개
-                        </S.GgulbeesStatementBtn>
+                        <S.GgulbeesStatementBeforeClickBtn onClick={GgulbeeClick}>
+                            TEAM HONEYARY
+                        </S.GgulbeesStatementBeforeClickBtn>
                     }
                 </S.Body>
             </S.TopWrapper>

--- a/src/pages/Information/Information.style.js
+++ b/src/pages/Information/Information.style.js
@@ -14,25 +14,39 @@ export const TopWrapper = styled.div`
 
 `
 export const Header = styled.div`
-    ${({ theme: { mixin } }) => mixin.flexBox({justify: 'center'})};
-    align-items: center;
-    margin: 3.2rem 0 1.6rem 0;
+    ${({ theme: { mixin } }) => mixin.flexBox({direction: 'column', justify: 'center'})};
+    align-items: start;
+    margin: 3.2rem 0 3.2rem 0;
+`
+export const Subtitle = styled.div`
+    ${({ theme }) => theme.fonts.title};
+    text-align: start;
+    margin: 0 1rem 0 1rem;
 `
 export const Title = styled.div`
-    ${({ theme }) => theme.fonts.title};
-    text-align: center;
-    margin: 0 2rem 0 2rem;
+    ${({ theme }) => theme.fonts.big_title};
+    text-align: start;
+    margin: 0.8rem 1rem 0 1.1rem;
 `
 export const Body = styled.div`
     ${({ theme: { mixin } }) => mixin.flexCenter({})};
     gap: 0.8rem;
 `
-export const Statement = styled.div`
+export const FirstStatement = styled.div`
     ${({ theme: { mixin } }) => mixin.flexCenter({})};
     ${({ theme }) => theme.fonts.body_06};
     width: 32rem;
-    border-radius: 2rem;
-    background-color: white;
+    border-radius: 1.2rem;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.00) 0%, #FFF 100%);
+    gap: 1.6rem;
+    padding: 2.4rem 2.4rem 1.6rem 2.4rem;
+`
+export const SecondStatement = styled.div`
+    ${({ theme: { mixin } }) => mixin.flexCenter({})};
+    ${({ theme }) => theme.fonts.body_06};
+    width: 32rem;
+    border-radius: 1.2rem;
+    background: linear-gradient(180deg, #FFF 0%, rgba(255, 255, 255, 0.00) 100%);
     gap: 1.6rem;
     padding: 2.4rem 2.4rem 1.6rem 2.4rem;
 `
@@ -40,49 +54,70 @@ export const HonearyBackgroundBtn = styled.button`
     ${({ theme }) => theme.fonts.heading_03};
     width: 32rem;
     height: 4rem;
-    border-radius: 2rem;
-    background-color: white;
+    border-radius: 1.2rem;
+    background-color: transparent;
 `
 export const GgulbeesStatementBtn = styled.button`
     ${({ theme }) => theme.fonts.heading_03};
     width: 32rem;
     height: 4rem;
-    border-radius: 2rem;
+    border-radius: 1.2rem;
+    background-color: transparent;
+`
+export const HonearyBackgroundBeforeClickBtn = styled.button`
+    ${({ theme }) => theme.fonts.heading_03};
+    width: 32rem;
+    height: 4rem;
+    border-radius: 1.2rem;
     background-color: white;
+`
+export const GgulbeesStatementBeforeClickBtn = styled.button`
+    ${({ theme }) => theme.fonts.heading_03};
+    display: flex;
+    flex-direction: row;
+    width: 32rem;
+    height: 4rem;
+    border-radius: 1.2rem;
+    background-color: white;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
 `
 export const Footer = styled.div`
     ${({ theme: { mixin } }) => mixin.flexCenter({})};
-    height: 7.5rem;
+    height: 6.8rem;
     justify-content: space-between;
-    margin: 1.6rem 0 3.2rem 0;
+    margin: 3.2rem 0 3.2rem 0;
 `
 export const FooterText = styled.p`
     ${({ theme }) => theme.fonts.caption_01};
-    margin-bottom: 2rem;
 `
 export const HoneyBear = styled(IcHoneyBear)``;
 export const format =styled.div`
     ${({ theme: { mixin } }) => mixin.flexBox({})};
 `
 export const GgulbeeFromatStatement1 =styled.p`
-    ${({ theme }) => theme.fonts.caption_01};
+    ${({ theme }) => theme.fonts.caption_02};
     margin-left: 1.6rem;
 `
 export const GgulbeeFromatStatement2 =styled.p`
-    ${({ theme }) => theme.fonts.caption_01};
+    ${({ theme }) => theme.fonts.caption_02};
     margin-right: 1.6rem;
 `
-export const GgulbeePhotooWrapper =styled.div`
+export const IntroductionText = styled.p`
+    ${({ theme }) => theme.fonts.caption_01};
+`
+export const GgulbeePhotoWrapper =styled.div`
     ${({ theme: { mixin } }) => mixin.flexCenter({})};
     ${({ theme }) => theme.fonts.caption_01};
 `
 export const GgulbeeInfoWrapper1 =styled.div`
     ${({ theme: { mixin } }) => mixin.flexBox({direction: 'column'})};
-    ${({ theme }) => theme.fonts.caption_01};
+    ${({ theme }) => theme.fonts.body_06};
 `
 export const GgulbeeInfoWrapper2 =styled.div`
     ${({ theme: { mixin } }) => mixin.flexBox({align: 'end', direction: 'column'})};
-    ${({ theme }) => theme.fonts.caption_01};
+    ${({ theme }) => theme.fonts.body_06};
 `
 export const GgulbeePhoto =styled.img`
     width: 6.4rem;

--- a/src/pages/Start/Start.jsx
+++ b/src/pages/Start/Start.jsx
@@ -31,7 +31,7 @@ function Start() {
     <S.StartPageWrapper>
       <S.TitleWrapper>
         <S.SubTitle>꿀같은 일상을 담는 일기서비스</S.SubTitle>
-        <S.Title>허니어리</S.Title>
+        <S.Title>허니어리 🍯</S.Title>
       </S.TitleWrapper>
 
       <HoneyBear width='100%' />

--- a/src/pages/Start/Start.style.js
+++ b/src/pages/Start/Start.style.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export const StartPageWrapper = styled.div`
   ${({ theme: { mixin } }) =>
     mixin.flexBox({ direction: 'column', justify: 'space-between', align: 'center' })};
-  ${({ theme }) => theme.fonts.heading_01};
+  ${({ theme }) => theme.fonts.title};
   background: ${({ theme }) => theme.colors.gradient.gradient_pink};
   color: ${({ theme }) => theme.colors.normal.black};
   width: 100%;


### PR DESCRIPTION
## Related Issue 🍫

- close : #[229] information_view style 수정

## Summary 🍪

https://github.com/user-attachments/assets/14bfbf2c-7e80-4959-a92f-d91ac6bcdd50


- information view 전체적인 스타일 촌스럽지 않도록... 수정했습니다!
- 꿀비들.. 이라는 말이 직관적이지 않아서 TEAM HONEYARY로 수정하였습니다.
- 팀원들의 역할이 잘 나타나도록 이름 아래에 역할를 추가했습니다! => 더 여유로운 화면 배치...ㅎ
- 추가로 information 페이지와 제목 부제목을 같게 하기 위해서 start 페이지 부제목 폰트 크기를 조금 수정했습니다!

## Before i request PR review 🍰

- 26일까지 수정할 시간이 많지 않다고 느껴져, 수정할 수 있는 부분만 가볍게 수정 느낌이 듭니다..!
- 그래도 전보다는 UI적으로 한 30% 더 개선된 느낌에 부끄럽지는 않을 수 있겠다...는 생각을 합니다!
- 26일 전까지 메인머지 할 수 있겠죠..!
